### PR TITLE
Added config for role customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Then `bundle` and add it to your `Capfile`:
 require 'capistrano/rake'
 ```
 
+## Configuration
+
+The following configuration is available:
+
+```ruby
+  # Defaults to [:app]
+  set :rake_roles, [:db, :app]
+```
 
 ## Usage
 
@@ -56,4 +64,3 @@ $ cap production invoke:rake TASK=paperclip:refresh
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/capistrano/rake/version.rb
+++ b/lib/capistrano/rake/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Rake
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end

--- a/lib/capistrano/tasks/invoke.rake
+++ b/lib/capistrano/tasks/invoke.rake
@@ -1,9 +1,12 @@
 namespace :invoke do
 
-  desc "Execute a rake task on a remote server"
+  # Defalut to :app roles
+  rake_roles = fetch(:rake_roles, :app)
+
+  desc "Execute a rake task on a remote server (cap invoke:rake TASK=db:migrate)"
   task :rake do
     if ENV['TASK']
-      on roles(:app) do
+      on roles(fetch(:rake_roles)) do
         within current_path do
           with rails_env: fetch(:rails_env) do
             execute :rake, ENV['TASK']
@@ -18,4 +21,3 @@ namespace :invoke do
   end
 
 end
-

--- a/lib/capistrano/tasks/invoke.rake
+++ b/lib/capistrano/tasks/invoke.rake
@@ -6,7 +6,7 @@ namespace :invoke do
   desc "Execute a rake task on a remote server (cap invoke:rake TASK=db:migrate)"
   task :rake do
     if ENV['TASK']
-      on roles(fetch(:rake_roles)) do
+      on roles(rake_roles) do
         within current_path do
           with rails_env: fetch(:rails_env) do
             execute :rake, ENV['TASK']


### PR DESCRIPTION
Adding a simple parameter for overriding the default role filtering. The default is still set to `:app`, which ensures the change is backward compatible. An update to the minor is sufficient as it's more important than a patch increment and doesn't break existing versions which disqualifies from an increment to the major. 

Lastly, the documentation has been updated to reflect the usage of this setting and for future settings to come.

@sheharyarn Please review.