### PR TITLE
Fetch rake_roles setting inside task instead of at code load time

### DIFF
--- a/lib/capistrano/tasks/invoke.rake
+++ b/lib/capistrano/tasks/invoke.rake
@@ -1,11 +1,12 @@
 namespace :invoke do
 
-  # Defalut to :app roles
-  rake_roles = fetch(:rake_roles, :app)
 
   desc "Execute a rake task on a remote server (cap invoke:rake TASK=db:migrate)"
   task :rake do
     if ENV['TASK']
+      # Default to :app roles
+      rake_roles = fetch(:rake_roles, :app)
+
       on roles(rake_roles) do
         within current_path do
           with rails_env: fetch(:rails_env) do


### PR DESCRIPTION
Previously, it would fetch rake_roles before you had the opportunity to set it in config/deploy.rb -- where you ordinarily set capistrano settings. So setting :rake_roles in config/deploy.rb had no effect. It is unclear to me where if anywhere you could set it to have an effect, it would have to be set *before* the task definition was even loaded. That is not quite right.

Now, since the capistrano setting is executed when the task is *executed*, not when it is loaded, setting rake_roles in your config/deploy.rb works just fine.